### PR TITLE
#1 - Authorization: Add PCGL AuthZ as authorization provider

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
@@ -1,10 +1,7 @@
 package bio.overture.score.server.auth;
 
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,14 +10,6 @@ public class AuthZAuthorizationService {
 
   @Value("${authz.admin.group}")
   private String ADMIN_GROUP;
-
-  private Optional<OAuth2AuthenticatedPrincipal> getPrincipalFromAuth(
-      Authentication authentication) {
-    if (authentication.getPrincipal() instanceof OAuth2AuthenticatedPrincipal) {
-      return Optional.ofNullable((OAuth2AuthenticatedPrincipal) authentication.getPrincipal());
-    }
-    return Optional.empty();
-  }
 
   public boolean isAdmin(AuthZClaims claims) {
     return claims.getGroups().contains(ADMIN_GROUP);

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
@@ -1,0 +1,74 @@
+package bio.overture.score.server.auth;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("secure")
+public class AuthZAuthorizationService {
+
+  @Value("${authz.admin.group}")
+  private String ADMIN_GROUP;
+
+  private Optional<OAuth2AuthenticatedPrincipal> getPrincipalFromAuth(
+      Authentication authentication) {
+    if (authentication.getPrincipal() instanceof OAuth2AuthenticatedPrincipal) {
+      return Optional.ofNullable((OAuth2AuthenticatedPrincipal) authentication.getPrincipal());
+    }
+    return Optional.empty();
+  }
+
+  public boolean isAdmin(Authentication authentication) {
+    if (ADMIN_GROUP == null) {
+      // ensure that the admin group is configured, don't allow access for admins if
+      // this is not configured.
+      return false;
+    }
+    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
+    if (principalOptional.isEmpty()) return false;
+    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
+    List<String> groups = principal.getAttribute("groups");
+    return groups != null && groups.contains(ADMIN_GROUP);
+  }
+
+  /**
+   * A user can edit a study if they have that study in their `editable_studies` list, or they are
+   * an admin
+   *
+   * @param authentication
+   * @param studyId
+   * @return
+   */
+  public boolean canEditStudy(Authentication authentication, String studyId) {
+    if (isAdmin(authentication)) return true;
+    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
+    if (principalOptional.isEmpty()) return false;
+    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
+    List<String> editableStudies = principal.getAttribute("editable_studies");
+    return isAdmin(authentication)
+        || (editableStudies != null && editableStudies.contains(studyId));
+  }
+
+  /**
+   * A user can edit a study if they have that study in their `readable_studies` list, or they are
+   * an admin
+   *
+   * @param authentication
+   * @param studyId
+   * @return
+   */
+  public boolean canReadStudy(Authentication authentication, String studyId) {
+    if (isAdmin(authentication)) return true;
+    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
+    if (principalOptional.isEmpty()) return false;
+    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
+    List<String> readableStudies = principal.getAttribute("readable_studies");
+    return isAdmin(authentication)
+        || (readableStudies != null && readableStudies.contains(studyId));
+  }
+}

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZAuthorizationService.java
@@ -1,6 +1,5 @@
 package bio.overture.score.server.auth;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -23,52 +22,31 @@ public class AuthZAuthorizationService {
     return Optional.empty();
   }
 
-  public boolean isAdmin(Authentication authentication) {
-    if (ADMIN_GROUP == null) {
-      // ensure that the admin group is configured, don't allow access for admins if
-      // this is not configured.
-      return false;
-    }
-    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
-    if (principalOptional.isEmpty()) return false;
-    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
-    List<String> groups = principal.getAttribute("groups");
-    return groups != null && groups.contains(ADMIN_GROUP);
+  public boolean isAdmin(AuthZClaims claims) {
+    return claims.getGroups().contains(ADMIN_GROUP);
   }
 
   /**
    * A user can edit a study if they have that study in their `editable_studies` list, or they are
    * an admin
    *
-   * @param authentication
+   * @param claims
    * @param studyId
    * @return
    */
-  public boolean canEditStudy(Authentication authentication, String studyId) {
-    if (isAdmin(authentication)) return true;
-    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
-    if (principalOptional.isEmpty()) return false;
-    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
-    List<String> editableStudies = principal.getAttribute("editable_studies");
-    return isAdmin(authentication)
-        || (editableStudies != null && editableStudies.contains(studyId));
+  public boolean canEditStudy(AuthZClaims claims, String studyId) {
+    return isAdmin(claims) || claims.getEditableStudies().contains(studyId);
   }
 
   /**
    * A user can edit a study if they have that study in their `readable_studies` list, or they are
    * an admin
    *
-   * @param authentication
+   * @param claims
    * @param studyId
    * @return
    */
-  public boolean canReadStudy(Authentication authentication, String studyId) {
-    if (isAdmin(authentication)) return true;
-    Optional<OAuth2AuthenticatedPrincipal> principalOptional = getPrincipalFromAuth(authentication);
-    if (principalOptional.isEmpty()) return false;
-    OAuth2AuthenticatedPrincipal principal = principalOptional.get();
-    List<String> readableStudies = principal.getAttribute("readable_studies");
-    return isAdmin(authentication)
-        || (readableStudies != null && readableStudies.contains(studyId));
+  public boolean canReadStudy(AuthZClaims claims, String studyId) {
+    return isAdmin(claims) || claims.getReadableStudies().contains(studyId);
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZClaims.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZClaims.java
@@ -1,0 +1,17 @@
+package bio.overture.score.server.auth;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthZClaims {
+  private final String sub;
+  private final List<Map<String, Object>> emails;
+  private final String primaryEmail;
+  private final List<String> editableStudies;
+  private final List<String> readableStudies;
+  private final List<String> groups;
+}

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZClaims.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZClaims.java
@@ -1,16 +1,14 @@
 package bio.overture.score.server.auth;
 
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 @Builder
 public class AuthZClaims {
+
   private final String sub;
-  private final List<Map<String, Object>> emails;
-  private final String primaryEmail;
   private final List<String> editableStudies;
   private final List<String> readableStudies;
   private final List<String> groups;

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZUserResponse.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZUserResponse.java
@@ -1,0 +1,47 @@
+package bio.overture.score.server.auth;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthZUserResponse {
+
+  @Data
+  @AllArgsConstructor
+  public class UserInfo {
+
+    @Data
+    @AllArgsConstructor
+    public class UserEmail {
+
+      private final String address;
+      private final String type;
+    }
+
+    private final List<UserEmail> emails;
+    private final String pcgl_id;
+  }
+
+  @Data
+  @AllArgsConstructor
+  public class StudyAuthorizations {
+
+    private final List<String> editable_studies;
+    private final List<String> readable_studies;
+  }
+
+  @Data
+  @AllArgsConstructor
+  public class Group {
+
+    private final String name;
+    private final String description;
+    private final int id;
+  }
+
+  private final UserInfo userinfo;
+  private final StudyAuthorizations study_authorizations;
+  private final List<Group> groups;
+}

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthZUserResponse.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthZUserResponse.java
@@ -1,47 +1,57 @@
 package bio.overture.score.server.auth;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Value;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class AuthZUserResponse {
 
   @Data
   @AllArgsConstructor
-  public class UserInfo {
+  @NoArgsConstructor
+  public static class UserInfo {
 
     @Data
     @AllArgsConstructor
-    public class UserEmail {
+    @NoArgsConstructor
+    public static class UserEmail {
 
-      private final String address;
-      private final String type;
+      private  String address;
+      private String type;
     }
 
-    private final List<UserEmail> emails;
-    private final String pcgl_id;
+    private  List<UserEmail> emails = new ArrayList<>();
+    private  String pcgl_id;
+    private boolean site_curator;
+    private boolean site_admin;
   }
 
   @Data
   @AllArgsConstructor
-  public class StudyAuthorizations {
+  @NoArgsConstructor
+  public static class StudyAuthorizations {
 
-    private final List<String> editable_studies;
-    private final List<String> readable_studies;
+    private  List<String> editable_studies = new ArrayList<>();
+    private  List<String> readable_studies = new ArrayList<>();
   }
 
   @Data
   @AllArgsConstructor
-  public class Group {
+  @NoArgsConstructor
+  public static class Group {
 
-    private final String name;
-    private final String description;
-    private final int id;
+    private  String name;
+    private  String description;
+    private  int id;
   }
 
-  private final UserInfo userinfo;
-  private final StudyAuthorizations study_authorizations;
-  private final List<Group> groups;
+  private  UserInfo userinfo;
+  private  StudyAuthorizations study_authorizations;
+  private  List<Group> groups;
 }

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthzTokenIntrospector.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthzTokenIntrospector.java
@@ -1,0 +1,103 @@
+package bio.overture.score.server.auth;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@Profile("secure")
+public class AuthzTokenIntrospector implements OpaqueTokenIntrospector {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  @Value("${authz.host}")
+  private String authzHost;
+
+  @Override
+  public OAuth2AuthenticatedPrincipal introspect(String token)
+      throws OAuth2AuthenticationException {
+
+    String url = UriComponentsBuilder.fromHttpUrl(authzHost).path("/user/me").toUriString();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, request, Map.class);
+
+      Map<String, Object> userDetails = response.getBody();
+
+      AuthZClaims claims = extractClaims(userDetails);
+
+      Map<String, Object> claimsMap =
+          Map.of(
+              "sub", claims.getSub(),
+              "emails", claims.getEmails(),
+              "primary_email", claims.getPrimaryEmail(),
+              "editable_studies", claims.getEditableStudies(),
+              "readable_studies", claims.getReadableStudies(),
+              "groups", claims.getGroups());
+      List<GrantedAuthority> authorities = extractAuthorities(claimsMap);
+      return new OAuth2IntrospectionAuthenticatedPrincipal(claimsMap, authorities);
+
+    } catch (Exception e) {
+      log.error("Failed to introspect token with AuthZ", e);
+      throw new OAuth2AuthenticationException(new OAuth2Error("invalid_token"), e.getMessage());
+    }
+  }
+
+  private AuthZClaims extractClaims(Map<String, Object> userDetails) {
+    Map<String, Object> userinfo = (Map<String, Object>) userDetails.get("userinfo");
+    Map<String, Object> studyAuths = (Map<String, Object>) userDetails.get("study_authorizations");
+    List<Map<String, Object>> groups = (List<Map<String, Object>>) userDetails.get("groups");
+
+    List<Map<String, Object>> emails = (List<Map<String, Object>>) userinfo.get("emails");
+    List<Map<String, Object>> safeEmails = (emails != null) ? emails : List.of();
+
+    String primaryEmail =
+        safeEmails.stream()
+            .filter(e -> "official".equalsIgnoreCase((String) e.get("type")))
+            .map(e -> (String) e.get("address"))
+            .findFirst()
+            .orElseGet(
+                () ->
+                    safeEmails.stream()
+                        .map(e -> (String) e.get("address"))
+                        .findFirst()
+                        .orElse(null));
+
+    return AuthZClaims.builder()
+        .sub((String) userinfo.get("pcgl_id"))
+        .emails(safeEmails)
+        .primaryEmail(primaryEmail)
+        .editableStudies((List<String>) studyAuths.get("editable_studies"))
+        .readableStudies((List<String>) studyAuths.get("readable_studies"))
+        .groups(groups.stream().map(g -> g.get("name").toString()).collect(Collectors.toList()))
+        .build();
+  }
+
+  private List<GrantedAuthority> extractAuthorities(Map<String, Object> claims) {
+    List<String> groups = (List<String>) claims.getOrDefault("groups", List.of());
+    return groups.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+  }
+}

--- a/score-server/src/main/java/bio/overture/score/server/auth/AuthzTokenIntrospector.java
+++ b/score-server/src/main/java/bio/overture/score/server/auth/AuthzTokenIntrospector.java
@@ -2,15 +2,17 @@ package bio.overture.score.server.auth;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -43,22 +45,16 @@ public class AuthzTokenIntrospector implements OpaqueTokenIntrospector {
     HttpEntity<Void> request = new HttpEntity<>(headers);
 
     try {
-      ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, request, Map.class);
+      ResponseEntity<AuthZUserResponse> response =
+          restTemplate.exchange(url, HttpMethod.GET, request, AuthZUserResponse.class);
 
-      Map<String, Object> userDetails = response.getBody();
+      AuthZUserResponse userDetails = response.getBody();
 
-      AuthZClaims claims = extractClaims(userDetails);
+      AuthZClaims claims = convertUserResponseToClaims(userDetails);
 
-      Map<String, Object> claimsMap =
-          Map.of(
-              "sub", claims.getSub(),
-              "emails", claims.getEmails(),
-              "primary_email", claims.getPrimaryEmail(),
-              "editable_studies", claims.getEditableStudies(),
-              "readable_studies", claims.getReadableStudies(),
-              "groups", claims.getGroups());
-      List<GrantedAuthority> authorities = extractAuthorities(claimsMap);
-      return new OAuth2IntrospectionAuthenticatedPrincipal(claimsMap, authorities);
+      Map<String, Object> claimsMap = Map.of("authzClaims", claims);
+      return new OAuth2IntrospectionAuthenticatedPrincipal(
+          claimsMap, List.of(new SimpleGrantedAuthority("user")));
 
     } catch (Exception e) {
       log.error("Failed to introspect token with AuthZ", e);
@@ -66,38 +62,33 @@ public class AuthzTokenIntrospector implements OpaqueTokenIntrospector {
     }
   }
 
-  private AuthZClaims extractClaims(Map<String, Object> userDetails) {
-    Map<String, Object> userinfo = (Map<String, Object>) userDetails.get("userinfo");
-    Map<String, Object> studyAuths = (Map<String, Object>) userDetails.get("study_authorizations");
-    List<Map<String, Object>> groups = (List<Map<String, Object>>) userDetails.get("groups");
+  public static Optional<AuthZClaims> extractClaimsFromAuthentication(
+      Authentication authentication) {
+    val principal = authentication.getPrincipal();
+    if (!(principal instanceof OAuth2AuthenticatedPrincipal)) {
+      return Optional.empty();
+    }
+    val claims = ((OAuth2AuthenticatedPrincipal) principal).getAttribute("authzClaims");
 
-    List<Map<String, Object>> emails = (List<Map<String, Object>>) userinfo.get("emails");
-    List<Map<String, Object>> safeEmails = (emails != null) ? emails : List.of();
+    if (!(claims instanceof AuthZClaims)) {
+      return Optional.empty();
+    }
 
-    String primaryEmail =
-        safeEmails.stream()
-            .filter(e -> "official".equalsIgnoreCase((String) e.get("type")))
-            .map(e -> (String) e.get("address"))
-            .findFirst()
-            .orElseGet(
-                () ->
-                    safeEmails.stream()
-                        .map(e -> (String) e.get("address"))
-                        .findFirst()
-                        .orElse(null));
-
-    return AuthZClaims.builder()
-        .sub((String) userinfo.get("pcgl_id"))
-        .emails(safeEmails)
-        .primaryEmail(primaryEmail)
-        .editableStudies((List<String>) studyAuths.get("editable_studies"))
-        .readableStudies((List<String>) studyAuths.get("readable_studies"))
-        .groups(groups.stream().map(g -> g.get("name").toString()).collect(Collectors.toList()))
-        .build();
+    return Optional.of((AuthZClaims) claims);
   }
 
-  private List<GrantedAuthority> extractAuthorities(Map<String, Object> claims) {
-    List<String> groups = (List<String>) claims.getOrDefault("groups", List.of());
-    return groups.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+  private AuthZClaims convertUserResponseToClaims(AuthZUserResponse userResponse) {
+
+    List<String> groupNames =
+        userResponse.getGroups().stream()
+            .map(group -> group.getName())
+            .collect(Collectors.toList());
+
+    return AuthZClaims.builder()
+        .sub(userResponse.getUserinfo().getPcgl_id())
+        .editableStudies(userResponse.getStudy_authorizations().getEditable_studies())
+        .readableStudies(userResponse.getStudy_authorizations().getReadable_studies())
+        .groups(groupNames)
+        .build();
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -17,7 +17,6 @@
  */
 package bio.overture.score.server.config;
 
-import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.auth.AuthzTokenIntrospector;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.properties.ScopeProperties;
@@ -80,16 +79,14 @@ public class SecurityConfig {
 
   @Bean
   public UploadScopeAuthorizationStrategy projectSecurity(
-      @Autowired MetadataService metadataService,
-      @Autowired AuthZAuthorizationService authZAuthorizationService) {
+      @Autowired MetadataService metadataService) {
 
     return new UploadScopeAuthorizationStrategy(
         scopeProperties.getUpload().getStudy().getPrefix(),
         scopeProperties.getUpload().getStudy().getSuffix(),
         scopeProperties.getUpload().getSystem(),
         metadataService,
-        provider,
-        authZAuthorizationService);
+        provider);
   }
 
   @Bean

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -78,6 +78,64 @@ public class SecurityConfig {
   }
 
   @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf().disable();
+    http.authorizeHttpRequests(
+            authorize ->
+                authorize
+                    .antMatchers("/isAlive")
+                    .permitAll()
+                    .antMatchers("/studies/**")
+                    .permitAll()
+                    .antMatchers("/upload/**")
+                    .permitAll()
+                    .antMatchers("/entities/**")
+                    .permitAll()
+                    .antMatchers("/export/**")
+                    .permitAll()
+                    .antMatchers("/schemas/**")
+                    .permitAll()
+                    .antMatchers()
+                    .permitAll()
+                    .antMatchers(
+                        swaggerConfig.getAlternateSwaggerUrl(),
+                        "/swagger**",
+                        "/swagger-ui.html",
+                        "/swagger-ui**",
+                        "/swagger-resources/**",
+                        "/v2/api-docs/**",
+                        "/webjars/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .oauth2ResourceServer(
+            oauth2 -> oauth2.authenticationManagerResolver(tokenAuthenticationManagerResolver()));
+
+    return http.build();
+  }
+
+  @Bean
+  public AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver() {
+
+    // PCGL AuthZ Provider:
+    if (provider.equals("pcglauthz")) {
+      return (request) ->
+          new ProviderManager(new OpaqueTokenAuthenticationProvider(authzTokenIntrospector));
+    }
+
+    // Non PCGL Authz Provider:
+    // Auth Managers for JWT and for ApiKeys. JWT uses the default auth provider,
+    // but OpaqueTokens are handled by the custom ApiKeyIntrospector
+    AuthenticationManager jwt = new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
+    AuthenticationManager opaqueToken =
+        new ProviderManager(
+            new OpaqueTokenAuthenticationProvider(
+                new ApiKeyIntrospector(url, clientId, clientSecret, tokenName)));
+
+    return (request) -> useJwt(request) ? jwt : opaqueToken;
+  }
+
+  @Bean
   public UploadScopeAuthorizationStrategy projectSecurity(
       @Autowired MetadataService metadataService) {
 
@@ -92,12 +150,12 @@ public class SecurityConfig {
   @Bean
   @Scope("prototype")
   public DownloadScopeAuthorizationStrategy accessSecurity(
-      @Autowired MetadataService song) {
+      @Autowired MetadataService metadataService) {
     return new DownloadScopeAuthorizationStrategy(
         scopeProperties.getDownload().getStudy().getPrefix(),
         scopeProperties.getDownload().getStudy().getSuffix(),
         scopeProperties.getDownload().getSystem(),
-        song,
+        metadataService,
         provider);
   }
 
@@ -124,78 +182,5 @@ public class SecurityConfig {
       }
     }
     return true;
-  }
-
-  @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.authorizeHttpRequests(
-            authorize ->
-                authorize
-                    .antMatchers("/isAlive")
-                    .permitAll()
-                    .antMatchers("/studies/**")
-                    .permitAll()
-                    .antMatchers("/upload/**")
-                    .permitAll()
-                    .antMatchers("/entities/**")
-                    .permitAll()
-                    .antMatchers("/export/**")
-                    .permitAll()
-                    .antMatchers("/schemas/**")
-                    .permitAll()
-                    .antMatchers(swaggerConfig.getAlternateSwaggerUrl())
-                    .permitAll()
-                    .antMatchers(
-                        "/swagger**",
-                        "/swagger-ui.html",
-                        "/swagger-ui**",
-                        "/swagger-resources/**",
-                        "/v2/api-docs/**",
-                        "/webjars/**")
-                    .permitAll()
-                    .anyRequest()
-                    .authenticated())
-        .oauth2ResourceServer(
-            oauth2 -> oauth2.authenticationManagerResolver(tokenAuthenticationManagerResolver()));
-
-    return http.build();
-  }
-
-  @Bean
-  public AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver() {
-    AuthenticationManager jwtManager =
-        new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
-
-    AuthenticationManager authzOpaqueManager =
-        new ProviderManager(new OpaqueTokenAuthenticationProvider(authzTokenIntrospector));
-
-    return (request) -> {
-      if (isAuthZRequest(request)) {
-        return authzOpaqueManager;
-      } else {
-        return jwtManager;
-      }
-    };
-  }
-
-  private boolean isAuthZRequest(HttpServletRequest request) {
-    // Option 1: Check for custom header
-    String providerHeader = request.getHeader("X-Auth-Provider");
-    if (providerHeader != null && providerHeader.equalsIgnoreCase("authz")) {
-      return true;
-    }
-
-    // Option 2: Detect based on token format
-    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-    if (authHeader != null && authHeader.startsWith("Bearer ")) {
-      String token = authHeader.substring(7);
-      return !isJwtToken(token); // Not a JWT => probably opaque AuthZ token
-    }
-
-    return false;
-  }
-
-  private boolean isJwtToken(String token) {
-    return token.split("\\.").length == 3;
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -95,15 +95,13 @@ public class SecurityConfig {
   @Bean
   @Scope("prototype")
   public DownloadScopeAuthorizationStrategy accessSecurity(
-      @Autowired MetadataService song,
-      @Autowired AuthZAuthorizationService authZAuthorizationService) {
+      @Autowired MetadataService song) {
     return new DownloadScopeAuthorizationStrategy(
         scopeProperties.getDownload().getStudy().getPrefix(),
         scopeProperties.getDownload().getStudy().getSuffix(),
         scopeProperties.getDownload().getSystem(),
         song,
-        provider,
-        authZAuthorizationService);
+        provider);
   }
 
   public ScopeProperties getScopeProperties() {

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -17,6 +17,8 @@
  */
 package bio.overture.score.server.config;
 
+import bio.overture.score.server.auth.AuthZAuthorizationService;
+import bio.overture.score.server.auth.AuthzTokenIntrospector;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.properties.ScopeProperties;
 import bio.overture.score.server.security.ApiKeyIntrospector;
@@ -38,11 +40,11 @@ import org.springframework.security.authentication.AuthenticationManagerResolver
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.OpaqueTokenAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * Resource service configuration file.<br>
@@ -55,7 +57,7 @@ import org.springframework.security.oauth2.server.resource.introspection.OpaqueT
 @Getter
 @Setter
 @ConfigurationProperties("auth.server")
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
   private String url;
   private String clientId;
@@ -67,76 +69,41 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired private JwtDecoder jwtDecoder;
 
+  @Autowired private AuthzTokenIntrospector authzTokenIntrospector;
+
+  @Autowired private SwaggerConfig swaggerConfig;
+
   @Autowired
   public SecurityConfig(@NonNull ScopeProperties scopeProperties) {
     this.scopeProperties = scopeProperties;
   }
 
-  @Override
-  public void configure(@NonNull HttpSecurity http) throws Exception {
-    http.csrf().disable();
-    configureAuthorization(http);
-  }
-
-  private void configureAuthorization(HttpSecurity http) throws Exception {
-    scopeProperties.logScopeProperties();
-
-    // @formatter:off
-    http.authorizeRequests()
-        .antMatchers("/health")
-        .permitAll()
-        .antMatchers("/actuator/health")
-        .permitAll()
-        .antMatchers("/upload/**")
-        .permitAll()
-        .antMatchers("/download/**")
-        .permitAll()
-        .antMatchers("/swagger**", "/swagger-resources/**", "/v2/api**", "/webjars/**")
-        .permitAll()
-        .and()
-        .authorizeRequests()
-        .anyRequest()
-        .authenticated();
-
-    http.oauth2ResourceServer(
-        oauth2 -> oauth2.authenticationManagerResolver(this.tokenAuthenticationManagerResolver()));
-    // @formatter:on
-    log.info("initialization done");
-  }
-
   @Bean
-  public AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver() {
+  public UploadScopeAuthorizationStrategy projectSecurity(
+      @Autowired MetadataService metadataService,
+      @Autowired AuthZAuthorizationService authZAuthorizationService) {
 
-    // Auth Managers for JWT and for ApiKeys. JWT uses the default auth provider,
-    // but OpaqueTokens are handled by the custom ApiKeyIntrospector
-    AuthenticationManager jwt = new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
-    AuthenticationManager opaqueToken =
-        new ProviderManager(
-            new OpaqueTokenAuthenticationProvider(
-                new ApiKeyIntrospector(url, clientId, clientSecret, tokenName)));
-
-    return (request) -> useJwt(request) ? jwt : opaqueToken;
-  }
-
-  @Bean
-  public UploadScopeAuthorizationStrategy projectSecurity(@Autowired MetadataService song) {
     return new UploadScopeAuthorizationStrategy(
         scopeProperties.getUpload().getStudy().getPrefix(),
         scopeProperties.getUpload().getStudy().getSuffix(),
         scopeProperties.getUpload().getSystem(),
-        song,
-        provider);
+        metadataService,
+        provider,
+        authZAuthorizationService);
   }
 
   @Bean
   @Scope("prototype")
-  public DownloadScopeAuthorizationStrategy accessSecurity(@Autowired MetadataService song) {
+  public DownloadScopeAuthorizationStrategy accessSecurity(
+      @Autowired MetadataService song,
+      @Autowired AuthZAuthorizationService authZAuthorizationService) {
     return new DownloadScopeAuthorizationStrategy(
         scopeProperties.getDownload().getStudy().getPrefix(),
         scopeProperties.getDownload().getStudy().getSuffix(),
         scopeProperties.getDownload().getSystem(),
         song,
-        provider);
+        provider,
+        authZAuthorizationService);
   }
 
   public ScopeProperties getScopeProperties() {
@@ -162,5 +129,78 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       }
     }
     return true;
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(
+            authorize ->
+                authorize
+                    .antMatchers("/isAlive")
+                    .permitAll()
+                    .antMatchers("/studies/**")
+                    .permitAll()
+                    .antMatchers("/upload/**")
+                    .permitAll()
+                    .antMatchers("/entities/**")
+                    .permitAll()
+                    .antMatchers("/export/**")
+                    .permitAll()
+                    .antMatchers("/schemas/**")
+                    .permitAll()
+                    .antMatchers(swaggerConfig.getAlternateSwaggerUrl())
+                    .permitAll()
+                    .antMatchers(
+                        "/swagger**",
+                        "/swagger-ui.html",
+                        "/swagger-ui**",
+                        "/swagger-resources/**",
+                        "/v2/api-docs/**",
+                        "/webjars/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .oauth2ResourceServer(
+            oauth2 -> oauth2.authenticationManagerResolver(tokenAuthenticationManagerResolver()));
+
+    return http.build();
+  }
+
+  @Bean
+  public AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver() {
+    AuthenticationManager jwtManager =
+        new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
+
+    AuthenticationManager authzOpaqueManager =
+        new ProviderManager(new OpaqueTokenAuthenticationProvider(authzTokenIntrospector));
+
+    return (request) -> {
+      if (isAuthZRequest(request)) {
+        return authzOpaqueManager;
+      } else {
+        return jwtManager;
+      }
+    };
+  }
+
+  private boolean isAuthZRequest(HttpServletRequest request) {
+    // Option 1: Check for custom header
+    String providerHeader = request.getHeader("X-Auth-Provider");
+    if (providerHeader != null && providerHeader.equalsIgnoreCase("authz")) {
+      return true;
+    }
+
+    // Option 2: Detect based on token format
+    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader != null && authHeader.startsWith("Bearer ")) {
+      String token = authHeader.substring(7);
+      return !isJwtToken(token); // Not a JWT => probably opaque AuthZ token
+    }
+
+    return false;
+  }
+
+  private boolean isJwtToken(String token) {
+    return token.split("\\.").length == 3;
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -102,7 +102,7 @@ public class S3DownloadService implements DownloadService {
 
       val objectKey = ObjectKeys.getObjectKey(dataDir, objectId);
 
-      var objectSpec = getSpecification(objectId);
+      ObjectSpecification objectSpec = getSpecification(objectId);
 
       if (objectSpec == null) {
         ObjectMetadata metadata =

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/AbstractScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/AbstractScopeAuthorizationStrategy.java
@@ -22,6 +22,9 @@ import static bio.overture.score.server.util.Scopes.extractGrantedScopesFromRpt;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.repository.auth.KeycloakAuthorizationService;
+import bio.overture.score.server.security.KeycloakPermission;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NonNull;
@@ -111,6 +114,24 @@ public abstract class AbstractScopeAuthorizationStrategy {
     } else {
       grantedScopes = extractGrantedScopes(authentication);
     }
+    return grantedScopes;
+  }
+
+  public static Set<String> extractGrantedScopesFromRpt(List<KeycloakPermission> permissionList) {
+    Set<String> grantedScopes = new HashSet();
+
+    permissionList.stream()
+        .filter(perm -> perm.getScopes() != null)
+        .forEach(
+            permission -> {
+              permission.getScopes().stream()
+                  .forEach(
+                      scope -> {
+                        val fullScope = permission.getRsname() + "." + scope;
+                        grantedScopes.add(fullScope);
+                      });
+            });
+
     return grantedScopes;
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
@@ -17,10 +17,10 @@
  */
 package bio.overture.score.server.security.scope;
 
+import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.security.Access;
-import java.util.Set;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -29,40 +29,55 @@ import org.springframework.security.core.Authentication;
 @Slf4j
 public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
 
+  private final AuthZAuthorizationService authZAuthorizationService;
+
   public DownloadScopeAuthorizationStrategy(
       @NonNull String studyPrefix,
       @NonNull String studySuffix,
       @NonNull String systemScope,
       MetadataService metadataService,
-      @NonNull String provider) {
+      @NonNull String provider,
+      @NonNull AuthZAuthorizationService authZAuthorizationService) {
     super(studyPrefix, studySuffix, systemScope, metadataService, provider);
+    this.authZAuthorizationService = authZAuthorizationService;
   }
 
   @Override
-  public boolean authorize(@NonNull Authentication authentication, @NonNull final String objectId) {
+  public boolean authorize(@NonNull Authentication authentication, @NonNull String objectId) {
 
-    Set<String> grantedScopes = getGrantedScopes(authentication);
+    log.info("Checking authorization for objectId {}", objectId);
 
-    log.info("Checking system-level authorization for objectId {}", objectId);
-    if (verifyOneOfSystemScope(grantedScopes)) {
-      return true;
-    }
-    log.info("Checking access control level for objectId {}", objectId);
     val fileAccessType = fetchFileAccessType(objectId);
     val accessType = new Access(fileAccessType);
+
     if (accessType.isOpen()) {
-      log.info("Access control level is open -- access granted");
+      log.info("File access is OPEN - granting access");
       return true;
-    } else if (accessType.isControlled()) {
-      log.info("Access control level is controlled -- checking study level authorization.");
-      return verifyOneOfStudyScope(grantedScopes, objectId);
-    } else {
-      val msg =
-          String.format(
-              "Invalid access type '%s' found in Metadata record for object id: %s",
-              fileAccessType, objectId);
-      log.error(msg);
-      throw new NotRetryableException(new IllegalArgumentException(msg));
     }
+
+    if (accessType.isControlled()) {
+      log.info("File access is CONTROLLED - checking user permissions");
+
+      String studyId = fetchStudyId(objectId);
+
+      boolean isAdmin = authZAuthorizationService.isAdmin(authentication);
+      boolean canWrite = authZAuthorizationService.canEditStudy(authentication, studyId);
+
+      if (isAdmin || canWrite) {
+        log.info("User has permission (admin or write access) for study {}", studyId);
+        return true;
+      } else {
+        log.warn("User does NOT have permission for study {}", studyId);
+        return false;
+      }
+    }
+
+    // Step 4: Unexpected access type
+    String msg =
+        String.format(
+            "Invalid access type '%s' found in Metadata record for object id: %s",
+            fileAccessType, objectId);
+    log.error(msg);
+    throw new NotRetryableException(new IllegalArgumentException(msg));
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
@@ -48,10 +48,8 @@ public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizati
       MetadataService metadataService,
       @NonNull String provider) {
     super(studyPrefix, studySuffix, systemScope, metadataService, provider);
-    //this.authZAuthorizationService = authZAuthorizationService;
   }
 
-  @Override
   public boolean authorize(@NonNull Authentication authentication, @NonNull String objectId) {
 
     log.info("Checking authorization for objectId {}", objectId);
@@ -69,14 +67,15 @@ public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizati
 
       String studyId = fetchStudyId(objectId);
 
-      if ("pcglauthz".equalsIgnoreCase(this.getProvider()) && authentication instanceof BearerTokenAuthentication) {
-        return authZAuthorizationService.isAdmin(authentication) ||
-                authZAuthorizationService.canEditStudy(authentication, studyId);
+      if ("pcglauthz".equalsIgnoreCase(this.getProvider())
+          && authentication instanceof BearerTokenAuthentication) {
+        return authZAuthorizationService.isAdmin(authentication)
+            || authZAuthorizationService.canEditStudy(authentication, studyId);
       } else if ("keycloak".equalsIgnoreCase(this.getProvider())
-              && authentication instanceof JwtAuthenticationToken) {
+          && authentication instanceof JwtAuthenticationToken) {
         val authGrants =
-                keycloakAuthorizationService.fetchAuthorizationGrants(
-                        ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
+            keycloakAuthorizationService.fetchAuthorizationGrants(
+                ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
         return verifyOneOfSystemScope(extractGrantedScopesFromRpt(authGrants));
       } else {
         // Default to EGO provider

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
@@ -18,26 +18,22 @@
 package bio.overture.score.server.security.scope;
 
 import bio.overture.score.server.auth.AuthZAuthorizationService;
+import bio.overture.score.server.auth.AuthzTokenIntrospector;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.repository.auth.KeycloakAuthorizationService;
 import bio.overture.score.server.security.Access;
-import bio.overture.score.server.util.Scopes;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-
-import static bio.overture.score.server.util.Scopes.extractGrantedScopesFromRpt;
 
 @Slf4j
 public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
 
-  @Autowired
-  private AuthZAuthorizationService authZAuthorizationService;
+  @Autowired private AuthZAuthorizationService authZAuthorizationService;
 
   @Autowired private KeycloakAuthorizationService keycloakAuthorizationService;
 
@@ -65,32 +61,31 @@ public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizati
     if (accessType.isControlled()) {
       log.info("File access is CONTROLLED - checking user permissions");
 
-      String studyId = fetchStudyId(objectId);
+      if ("pcglauthz".equalsIgnoreCase(this.getProvider())) {
 
-      if ("pcglauthz".equalsIgnoreCase(this.getProvider())
-          && authentication instanceof BearerTokenAuthentication) {
-        return authZAuthorizationService.isAdmin(authentication)
-            || authZAuthorizationService.canEditStudy(authentication, studyId);
-      } else if ("keycloak".equalsIgnoreCase(this.getProvider())
-          && authentication instanceof JwtAuthenticationToken) {
-        val authGrants =
-            keycloakAuthorizationService.fetchAuthorizationGrants(
-                ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
-        return verifyOneOfSystemScope(extractGrantedScopesFromRpt(authGrants));
-      } else {
-        // Default to EGO provider
-        // extract scopes from authentication object
-        return verifyOneOfSystemScope(Scopes.extractGrantedScopes(authentication));
+        String studyId = fetchStudyId(objectId);
+        if (studyId == null) {
+          log.warn("No study found for objectId {}", objectId);
+          return false;
+        }
+        val claims = AuthzTokenIntrospector.extractClaimsFromAuthentication(authentication);
+
+        return claims.isPresent()
+            ? authZAuthorizationService.canReadStudy(claims.get(), studyId)
+            : false;
       }
 
+      Set<String> grantedScopes = getGrantedScopes(authentication);
+      log.info("Checking system-level authorization for objectId {}", objectId);
+      return verifyOneOfSystemScope(grantedScopes)
+          || verifyOneOfStudyScope(grantedScopes, objectId);
+    } else {
+      val msg =
+          String.format(
+              "Invalid access type '%s' found in Metadata record for object id: %s",
+              fileAccessType, objectId);
+      log.error(msg);
+      throw new NotRetryableException(new IllegalArgumentException(msg));
     }
-
-    // Step 4: Unexpected access type
-    String msg =
-        String.format(
-            "Invalid access type '%s' found in Metadata record for object id: %s",
-            fileAccessType, objectId);
-    log.error(msg);
-    throw new NotRetryableException(new IllegalArgumentException(msg));
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/DownloadScopeAuthorizationStrategy.java
@@ -20,26 +20,35 @@ package bio.overture.score.server.security.scope;
 import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataService;
+import bio.overture.score.server.repository.auth.KeycloakAuthorizationService;
 import bio.overture.score.server.security.Access;
+import bio.overture.score.server.util.Scopes;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import static bio.overture.score.server.util.Scopes.extractGrantedScopesFromRpt;
 
 @Slf4j
 public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
 
-  private final AuthZAuthorizationService authZAuthorizationService;
+  @Autowired
+  private AuthZAuthorizationService authZAuthorizationService;
+
+  @Autowired private KeycloakAuthorizationService keycloakAuthorizationService;
 
   public DownloadScopeAuthorizationStrategy(
       @NonNull String studyPrefix,
       @NonNull String studySuffix,
       @NonNull String systemScope,
       MetadataService metadataService,
-      @NonNull String provider,
-      @NonNull AuthZAuthorizationService authZAuthorizationService) {
+      @NonNull String provider) {
     super(studyPrefix, studySuffix, systemScope, metadataService, provider);
-    this.authZAuthorizationService = authZAuthorizationService;
+    //this.authZAuthorizationService = authZAuthorizationService;
   }
 
   @Override
@@ -60,16 +69,21 @@ public class DownloadScopeAuthorizationStrategy extends AbstractScopeAuthorizati
 
       String studyId = fetchStudyId(objectId);
 
-      boolean isAdmin = authZAuthorizationService.isAdmin(authentication);
-      boolean canWrite = authZAuthorizationService.canEditStudy(authentication, studyId);
-
-      if (isAdmin || canWrite) {
-        log.info("User has permission (admin or write access) for study {}", studyId);
-        return true;
+      if ("pcglauthz".equalsIgnoreCase(this.getProvider()) && authentication instanceof BearerTokenAuthentication) {
+        return authZAuthorizationService.isAdmin(authentication) ||
+                authZAuthorizationService.canEditStudy(authentication, studyId);
+      } else if ("keycloak".equalsIgnoreCase(this.getProvider())
+              && authentication instanceof JwtAuthenticationToken) {
+        val authGrants =
+                keycloakAuthorizationService.fetchAuthorizationGrants(
+                        ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
+        return verifyOneOfSystemScope(extractGrantedScopesFromRpt(authGrants));
       } else {
-        log.warn("User does NOT have permission for study {}", studyId);
-        return false;
+        // Default to EGO provider
+        // extract scopes from authentication object
+        return verifyOneOfSystemScope(Scopes.extractGrantedScopes(authentication));
       }
+
     }
 
     // Step 4: Unexpected access type

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
@@ -17,16 +17,14 @@
 package bio.overture.score.server.security.scope;
 
 import bio.overture.score.server.auth.AuthZAuthorizationService;
+import bio.overture.score.server.auth.AuthzTokenIntrospector;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.repository.auth.KeycloakAuthorizationService;
-import bio.overture.score.server.util.Scopes;
 import java.util.Set;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 @Slf4j
 public class UploadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
@@ -45,27 +43,29 @@ public class UploadScopeAuthorizationStrategy extends AbstractScopeAuthorization
   }
 
   public boolean authorize(@NonNull Authentication authentication, @NonNull final String objectId) {
-    log.info("Checking upload authorization for objectId {}", objectId);
 
-    String studyId = fetchStudyId(objectId);
+    // PCGL AuthZ
+    if ("pcglauthz".equalsIgnoreCase(this.getProvider())) {
+      String studyId = fetchStudyId(objectId);
 
-    if (studyId == null) {
-      log.warn("No study found for objectId {}", objectId);
-      return false;
+      if (studyId == null) {
+        log.warn("No study found for objectId {}", objectId);
+        return false;
+      }
+      val claims = AuthzTokenIntrospector.extractClaimsFromAuthentication(authentication);
+      return claims.isPresent()
+          ? authZAuthorizationService.canEditStudy(claims.get(), studyId)
+          : false;
     }
 
-    Set<String> grantedScopes;
-    if ("pcglauthz".equalsIgnoreCase(this.getProvider())
-        && authentication instanceof BearerTokenAuthentication) {
-      return authZAuthorizationService.isAdmin(authentication);
-    } else if ("keycloak".equalsIgnoreCase(this.getProvider())
-        && authentication instanceof JwtAuthenticationToken) {
-      val authGrants =
-          keycloakAuthorizationService.fetchAuthorizationGrants(
-              ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
-      return verifyOneOfSystemScope(extractGrantedScopesFromRpt(authGrants));
-    } else {
-      return verifyOneOfSystemScope(Scopes.extractGrantedScopes(authentication));
+    // Provider is not PCGL AuthZ:
+    Set<String> grantedScopes = getGrantedScopes(authentication);
+
+    if (verifyOneOfSystemScope(grantedScopes)) {
+      log.info("System-level upload authorization granted");
+      return true;
     }
+    log.info("Checking study-level authorization for objectId {}", objectId);
+    return verifyOneOfStudyScope(grantedScopes, objectId);
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
@@ -16,8 +16,8 @@
  */
 package bio.overture.score.server.security.scope;
 
+import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.metadata.MetadataService;
-import java.util.Set;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -25,24 +25,45 @@ import org.springframework.security.core.Authentication;
 @Slf4j
 public class UploadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
 
+  private final AuthZAuthorizationService authZAuthorizationService;
+
   public UploadScopeAuthorizationStrategy(
       @NonNull String studyPrefix,
       @NonNull String studySuffix,
       @NonNull String systemScope,
       @NonNull MetadataService metadataService,
-      @NonNull String provider) {
+      @NonNull String provider,
+      @NonNull AuthZAuthorizationService authZAuthorizationService) {
     super(studyPrefix, studySuffix, systemScope, metadataService, provider);
+    this.authZAuthorizationService = authZAuthorizationService;
   }
 
   public boolean authorize(@NonNull Authentication authentication, @NonNull final String objectId) {
+    log.info("Checking upload authorization for objectId {}", objectId);
 
-    Set<String> grantedScopes = getGrantedScopes(authentication);
+    String studyId = fetchStudyId(objectId);
 
-    if (verifyOneOfSystemScope(grantedScopes)) {
-      log.info("System-level upload authorization granted");
-      return true;
+    if (studyId == null) {
+      log.warn("No study found for objectId {}", objectId);
+      return false;
     }
-    log.info("Checking study-level authorization for objectId {}", objectId);
-    return verifyOneOfStudyScope(grantedScopes, objectId);
+
+    boolean isAuthorized =
+        authZAuthorizationService.isAdmin(authentication)
+            || authZAuthorizationService.canEditStudy(authentication, studyId);
+
+    if (isAuthorized) {
+      log.info(
+          "Authorization granted for user {} to upload to study {}",
+          authentication.getName(),
+          studyId);
+    } else {
+      log.info(
+          "Authorization denied for user {} to upload to study {}",
+          authentication.getName(),
+          studyId);
+    }
+
+    return isAuthorized;
   }
 }

--- a/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/scope/UploadScopeAuthorizationStrategy.java
@@ -18,24 +18,30 @@ package bio.overture.score.server.security.scope;
 
 import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.metadata.MetadataService;
+import bio.overture.score.server.repository.auth.KeycloakAuthorizationService;
+import bio.overture.score.server.util.Scopes;
+import java.util.Set;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 @Slf4j
 public class UploadScopeAuthorizationStrategy extends AbstractScopeAuthorizationStrategy {
 
-  private final AuthZAuthorizationService authZAuthorizationService;
+  @Autowired private AuthZAuthorizationService authZAuthorizationService;
+
+  @Autowired private KeycloakAuthorizationService keycloakAuthorizationService;
 
   public UploadScopeAuthorizationStrategy(
       @NonNull String studyPrefix,
       @NonNull String studySuffix,
       @NonNull String systemScope,
       @NonNull MetadataService metadataService,
-      @NonNull String provider,
-      @NonNull AuthZAuthorizationService authZAuthorizationService) {
+      @NonNull String provider) {
     super(studyPrefix, studySuffix, systemScope, metadataService, provider);
-    this.authZAuthorizationService = authZAuthorizationService;
   }
 
   public boolean authorize(@NonNull Authentication authentication, @NonNull final String objectId) {
@@ -48,22 +54,18 @@ public class UploadScopeAuthorizationStrategy extends AbstractScopeAuthorization
       return false;
     }
 
-    boolean isAuthorized =
-        authZAuthorizationService.isAdmin(authentication)
-            || authZAuthorizationService.canEditStudy(authentication, studyId);
-
-    if (isAuthorized) {
-      log.info(
-          "Authorization granted for user {} to upload to study {}",
-          authentication.getName(),
-          studyId);
+    Set<String> grantedScopes;
+    if ("pcglauthz".equalsIgnoreCase(this.getProvider())
+        && authentication instanceof BearerTokenAuthentication) {
+      return authZAuthorizationService.isAdmin(authentication);
+    } else if ("keycloak".equalsIgnoreCase(this.getProvider())
+        && authentication instanceof JwtAuthenticationToken) {
+      val authGrants =
+          keycloakAuthorizationService.fetchAuthorizationGrants(
+              ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
+      return verifyOneOfSystemScope(extractGrantedScopesFromRpt(authGrants));
     } else {
-      log.info(
-          "Authorization denied for user {} to upload to study {}",
-          authentication.getName(),
-          studyId);
+      return verifyOneOfSystemScope(Scopes.extractGrantedScopes(authentication));
     }
-
-    return isAuthorized;
   }
 }

--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -243,6 +243,10 @@ auth:
         study:
           prefix: PROGRAMDATA-
           suffix: .WRITE
+authz:
+  host:
+  admin:
+    group:
 
 ---
 ###############################################################################

--- a/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
@@ -47,9 +47,7 @@ import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -62,7 +60,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
@@ -94,7 +91,7 @@ public class DownloadScopeAuthorizationStrategyTest {
   @MockBean private UploadService uploadService;
   @Mock private AuthZAuthorizationService authZAuthorizationService;
 
-  //@InjectMocks private DownloadScopeAuthorizationStrategy downloadScopeAuthorizationStrategy;
+  // @InjectMocks private DownloadScopeAuthorizationStrategy downloadScopeAuthorizationStrategy;
 
   private DownloadScopeAuthorizationStrategy sut;
 
@@ -108,10 +105,10 @@ public class DownloadScopeAuthorizationStrategyTest {
     }
 
     sut = init();
-    ReflectionTestUtils.setField( sut,"authZAuthorizationService", authZAuthorizationService);
+    ReflectionTestUtils.setField(sut, "authZAuthorizationService", authZAuthorizationService);
   }
 
-   // System Under Test
+  // System Under Test
 
   public MetadataService getMetadataService() {
     val metadataService = mock(MetadataService.class);
@@ -128,11 +125,7 @@ public class DownloadScopeAuthorizationStrategyTest {
 
   public DownloadScopeAuthorizationStrategy init() {
     return new DownloadScopeAuthorizationStrategy(
-        STUDY_PREFIX,
-        DOWNLOAD_SUFFIX,
-        SYSTEM_SCOPE,
-        getMetadataService(),
-        PROVIDER_EGO);
+        STUDY_PREFIX, DOWNLOAD_SUFFIX, SYSTEM_SCOPE, getMetadataService(), PROVIDER_EGO);
   }
 
   public MetadataEntity entity(

--- a/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
@@ -47,6 +47,9 @@ import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -56,8 +59,10 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
@@ -87,7 +92,11 @@ public class DownloadScopeAuthorizationStrategyTest {
   @MockBean private MetadataService metadataService;
   @MockBean private DownloadService downloadService;
   @MockBean private UploadService uploadService;
-  @MockBean private static AuthZAuthorizationService authZAuthorizationService;
+  @Mock private AuthZAuthorizationService authZAuthorizationService;
+
+  //@InjectMocks private DownloadScopeAuthorizationStrategy downloadScopeAuthorizationStrategy;
+
+  private DownloadScopeAuthorizationStrategy sut;
 
   @Before
   @SneakyThrows
@@ -97,9 +106,12 @@ public class DownloadScopeAuthorizationStrategyTest {
       this.mockMvc =
           MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
     }
+
+    sut = init();
+    ReflectionTestUtils.setField( sut,"authZAuthorizationService", authZAuthorizationService);
   }
 
-  private DownloadScopeAuthorizationStrategy sut = init(); // System Under Test
+   // System Under Test
 
   public MetadataService getMetadataService() {
     val metadataService = mock(MetadataService.class);
@@ -120,8 +132,7 @@ public class DownloadScopeAuthorizationStrategyTest {
         DOWNLOAD_SUFFIX,
         SYSTEM_SCOPE,
         getMetadataService(),
-        PROVIDER_EGO,
-        authZAuthorizationService);
+        PROVIDER_EGO);
   }
 
   public MetadataEntity entity(
@@ -217,7 +228,7 @@ public class DownloadScopeAuthorizationStrategyTest {
     val choices = List.of(false, true);
     boolean everythingPassed = true;
     for (val hasOther : choices) {
-      val result = run_test(false, false, true, hasOther);
+      val result = run_test(false, true, true, hasOther);
       if (!result) {
         System.err.printf(
             "Access wasn't granted to non-expired token (scopes='%s')",
@@ -287,7 +298,7 @@ public class DownloadScopeAuthorizationStrategyTest {
     } catch (NotRetryableException e) {
       exception = e;
     }
-    assertNull(exception);
-    assertTrue(status);
+    assertNotNull(exception);
+    assertFalse(status);
   }
 }

--- a/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
@@ -91,8 +91,7 @@ public class DownloadScopeAuthorizationStrategyTest {
   @MockBean private UploadService uploadService;
   @Mock private AuthZAuthorizationService authZAuthorizationService;
 
-  // @InjectMocks private DownloadScopeAuthorizationStrategy downloadScopeAuthorizationStrategy;
-
+  // System Under Test
   private DownloadScopeAuthorizationStrategy sut;
 
   @Before
@@ -107,8 +106,6 @@ public class DownloadScopeAuthorizationStrategyTest {
     sut = init();
     ReflectionTestUtils.setField(sut, "authZAuthorizationService", authZAuthorizationService);
   }
-
-  // System Under Test
 
   public MetadataService getMetadataService() {
     val metadataService = mock(MetadataService.class);
@@ -221,7 +218,7 @@ public class DownloadScopeAuthorizationStrategyTest {
     val choices = List.of(false, true);
     boolean everythingPassed = true;
     for (val hasOther : choices) {
-      val result = run_test(false, true, true, hasOther);
+      val result = run_test(false, false, true, hasOther);
       if (!result) {
         System.err.printf(
             "Access wasn't granted to non-expired token (scopes='%s')",
@@ -278,20 +275,5 @@ public class DownloadScopeAuthorizationStrategyTest {
     assertEquals(
         "java.lang.IllegalArgumentException: Failed to retrieve metadata for objectId: non-existent",
         exception.getMessage());
-  }
-
-  @Test
-  public void test_system_scope_object_not_looked_up() {
-    val scopes = Set.of(SYSTEM_SCOPE);
-    val auth = getAuthentication(scopes);
-    Exception exception = null;
-    boolean status = false;
-    try {
-      status = sut.authorize(auth, "non-existent");
-    } catch (NotRetryableException e) {
-      exception = e;
-    }
-    assertNotNull(exception);
-    assertFalse(status);
   }
 }

--- a/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/DownloadScopeAuthorizationStrategyTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.config.SecurityConfig;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataEntity;
@@ -86,6 +87,7 @@ public class DownloadScopeAuthorizationStrategyTest {
   @MockBean private MetadataService metadataService;
   @MockBean private DownloadService downloadService;
   @MockBean private UploadService uploadService;
+  @MockBean private static AuthZAuthorizationService authZAuthorizationService;
 
   @Before
   @SneakyThrows
@@ -114,7 +116,12 @@ public class DownloadScopeAuthorizationStrategyTest {
 
   public DownloadScopeAuthorizationStrategy init() {
     return new DownloadScopeAuthorizationStrategy(
-        STUDY_PREFIX, DOWNLOAD_SUFFIX, SYSTEM_SCOPE, getMetadataService(), PROVIDER_EGO);
+        STUDY_PREFIX,
+        DOWNLOAD_SUFFIX,
+        SYSTEM_SCOPE,
+        getMetadataService(),
+        PROVIDER_EGO,
+        authZAuthorizationService);
   }
 
   public MetadataEntity entity(

--- a/score-server/src/test/java/bio/overture/score/server/security/JWTSecurityTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/JWTSecurityTest.java
@@ -96,14 +96,14 @@ public class JWTSecurityTest {
       downloadScopesMap =
           Map.of(
               VALID_SYSTEM, List.of(resolveSystemDownloadScope(), "id.READ"),
-              VALID_STUDY, List.of(resolveStudyDownloadScope(EXISTING_PROJECT_CODE), "id.READ"),
+              VALID_STUDY, List.of(resolveStudyDownloadScope(EXISTING_PROJECT_CODE), "score.READ"),
               INVALID_STUDY,
                   List.of(resolveStudyDownloadScope(NON_EXISTING_PROJECT_CODE), "id.READ"));
 
       uploadScopesMap =
           Map.of(
               VALID_SYSTEM, List.of(resolveSystemUploadScope(), "id.WRITE"),
-              VALID_STUDY, List.of(resolveStudyUploadScope(EXISTING_PROJECT_CODE), "id.WRITE"),
+              VALID_STUDY, List.of(resolveStudyUploadScope(EXISTING_PROJECT_CODE), "score.WRITE"),
               INVALID_STUDY,
                   List.of(resolveStudyUploadScope(NON_EXISTING_PROJECT_CODE), "id.WRITE"));
     }

--- a/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
@@ -162,7 +162,7 @@ public class UploadScopeAuthorizationStrategyTest {
   public void test_study_scope_ok() {
     val scopes = Set.of(TEST_SCOPE, STUDY_PREFIX + PROJECT1 + ".upload");
     val authentication = getAuthentication(scopes);
-    assertFalse(sut.authorize(authentication, "1"));
+    assertTrue(sut.authorize(authentication, "1"));
   }
 
   @Test
@@ -199,7 +199,7 @@ public class UploadScopeAuthorizationStrategyTest {
     } catch (NotRetryableException e) {
       exception = e;
     }
-    assertNotNull(exception);
-    assertFalse(status);
+    assertNull(exception);
+    assertTrue(status);
   }
 }

--- a/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
@@ -85,7 +85,7 @@ public class UploadScopeAuthorizationStrategyTest {
   @MockBean private MetadataService metadataService;
   @MockBean private DownloadService downloadService;
   @MockBean private UploadService uploadService;
-  @MockBean private static AuthZAuthorizationService authZAuthorizationService;
+  @MockBean private AuthZAuthorizationService authZAuthorizationService;
 
   @Before
   @SneakyThrows
@@ -95,11 +95,7 @@ public class UploadScopeAuthorizationStrategyTest {
       this.mockMvc =
           MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
     }
-  }
 
-  private UploadScopeAuthorizationStrategy sut = init();
-
-  public static UploadScopeAuthorizationStrategy init() {
     val e1 = MetadataEntity.builder().projectCode(PROJECT1).id("1").build();
     val e2 = MetadataEntity.builder().projectCode(PROJECT2).id("2").build();
 
@@ -107,9 +103,12 @@ public class UploadScopeAuthorizationStrategyTest {
     when(meta.getEntity("1")).thenReturn(e1);
     when(meta.getEntity("2")).thenReturn(e2);
 
-    return new UploadScopeAuthorizationStrategy(
-        STUDY_PREFIX, UPLOAD_SUFFIX, SYSTEM_SCOPE, meta, PROVIDER_EGO, authZAuthorizationService);
+    sut =
+        new UploadScopeAuthorizationStrategy(
+            STUDY_PREFIX, UPLOAD_SUFFIX, SYSTEM_SCOPE, meta, PROVIDER_EGO);
   }
+
+  private UploadScopeAuthorizationStrategy sut;
 
   @SneakyThrows
   private Authentication getAuthentication(Set<String> scopes) {
@@ -163,7 +162,7 @@ public class UploadScopeAuthorizationStrategyTest {
   public void test_study_scope_ok() {
     val scopes = Set.of(TEST_SCOPE, STUDY_PREFIX + PROJECT1 + ".upload");
     val authentication = getAuthentication(scopes);
-    assertTrue(sut.authorize(authentication, "1"));
+    assertFalse(sut.authorize(authentication, "1"));
   }
 
   @Test
@@ -200,7 +199,7 @@ public class UploadScopeAuthorizationStrategyTest {
     } catch (NotRetryableException e) {
       exception = e;
     }
-    assertNull(exception);
-    assertTrue(status);
+    assertNotNull(exception);
+    assertFalse(status);
   }
 }

--- a/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/security/UploadScopeAuthorizationStrategyTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import bio.overture.score.server.auth.AuthZAuthorizationService;
 import bio.overture.score.server.config.SecurityConfig;
 import bio.overture.score.server.exception.NotRetryableException;
 import bio.overture.score.server.metadata.MetadataEntity;
@@ -84,6 +85,7 @@ public class UploadScopeAuthorizationStrategyTest {
   @MockBean private MetadataService metadataService;
   @MockBean private DownloadService downloadService;
   @MockBean private UploadService uploadService;
+  @MockBean private static AuthZAuthorizationService authZAuthorizationService;
 
   @Before
   @SneakyThrows
@@ -106,7 +108,7 @@ public class UploadScopeAuthorizationStrategyTest {
     when(meta.getEntity("2")).thenReturn(e2);
 
     return new UploadScopeAuthorizationStrategy(
-        STUDY_PREFIX, UPLOAD_SUFFIX, SYSTEM_SCOPE, meta, PROVIDER_EGO);
+        STUDY_PREFIX, UPLOAD_SUFFIX, SYSTEM_SCOPE, meta, PROVIDER_EGO, authZAuthorizationService);
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Summary 
Add new authorization provider that will authenticate user requests using [PCGL AuthZ](https://github.com/Pan-Canadian-Genome-Library/pcgl-authz).

### Related Issues
- #1
- #2
- #3 
- #4 
- #5 

## Description of Changes

### Score Server
- `AuthZTokenIntrospector` to verify opaque authorization tokens with AuthZ and return `AuthZClaims`
- `AuthZAuthorizationService` to authorize user requests based on the content of their `AuthZClaims`
   - isAdmin based on configurable group membership
   - write permission based on `editable_studies`
   - read permission based on `readable_studies`
- Establish new provider `pcglauthz` that will use the new token introspector and auth service to authorize requests
   - Update `SecurityConfig` to use `AuthZTokenIntrospector`
   - Update `authorize` functions for `DownloadScopeAuthorizationStrategy` and `UploadScopeAuthorizationStrategy` to use `AuthZAuthorizationService`

## Deployment Instructions
To configure this service to use AuthZ, the environmental config `AUTH_SERVER_PROVIDER` must be set to be `pcglauthz`. This will then require setting the `authz` config properties:

- `AUTHZ_HOST` must be given the URL to connect to the AuthZ API.
- `AUTHZ_ADMIN_GROUP` should be given the group name that will be matched to confirm that a user is an admin for this service.