### PR TITLE
Refactor - Standardize Authorization requirements for all controllers (#495)

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/config/ProfileConfig.java
+++ b/score-client/src/main/java/bio/overture/score/client/config/ProfileConfig.java
@@ -30,10 +30,6 @@ public class ProfileConfig {
   @Value("${defaultProfile:s3}")
   private String defaultProfile;
 
-  @Autowired
-  @Value("${isTest}")
-  private boolean isTest = false;
-
   @Qualifier("clientVersion")
   @Autowired
   @NonNull

--- a/score-client/src/main/java/bio/overture/score/client/exception/ConnectivityResponseHandler.java
+++ b/score-client/src/main/java/bio/overture/score/client/exception/ConnectivityResponseHandler.java
@@ -33,18 +33,14 @@ public class ConnectivityResponseHandler extends DefaultResponseErrorHandler {
     val status = response.getStatusCode();
     switch (status) {
       case FORBIDDEN:
-        log.warn(
-            "Connection to object storage refused, received response code FORBIDDEN.");
+        log.warn("Connection to object storage refused, received response code FORBIDDEN.");
         throw notRetryableException(
-            "Connection to object storage refused, received response code FORBIDDEN.",
-            response);
+            "Connection to object storage refused, received response code FORBIDDEN.", response);
 
       case REQUEST_TIMEOUT:
-        log.warn(
-            "Connection to object storage failed, request timed out.");
+        log.warn("Connection to object storage failed, request timed out.");
         throw notRetryableException(
-            "Connection to object storage failed, request timed out.",
-            response);
+            "Connection to object storage failed, request timed out.", response);
 
       default:
         log.warn("Non-Retryable exception: {}", response.getStatusText());

--- a/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
+++ b/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+
 @Value
 public class DownloadManifest {
   @NonNull private final List<ManifestEntry> entries;

--- a/score-core/src/main/java/bio/overture/score/core/security/ssl/SSLCertificateValidation.java
+++ b/score-core/src/main/java/bio/overture/score/core/security/ssl/SSLCertificateValidation.java
@@ -17,9 +17,6 @@
  */
 package bio.overture.score.core.security.ssl;
 
-import bio.overture.score.core.security.ssl.NoTestHostnameVerifier;
-import bio.overture.score.core.security.ssl.NoTestX509TrustManager;
-
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired private JwtDecoder jwtDecoder;
 
+  @Autowired private SwaggerConfig swaggerConfig;
+
   @Autowired
   public SecurityConfig(@NonNull ScopeProperties scopeProperties) {
     this.scopeProperties = scopeProperties;
@@ -83,15 +85,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     // @formatter:off
     http.authorizeRequests()
-        .antMatchers("/health")
-        .permitAll()
         .antMatchers("/actuator/health")
         .permitAll()
-        .antMatchers("/upload/**")
+        .antMatchers("/profile")
         .permitAll()
-        .antMatchers("/download/**")
+        .antMatchers("/download/ping")
         .permitAll()
-        .antMatchers("/swagger**", "/swagger-resources/**", "/v2/api**", "/webjars/**")
+        .antMatchers(
+            swaggerConfig.getAlternateSwaggerUrl(),
+            "/swagger**",
+            "/swagger-resources/**",
+            "/v2/api**",
+            "/webjars/**")
         .permitAll()
         .and()
         .authorizeRequests()

--- a/score-server/src/main/java/bio/overture/score/server/config/SwaggerConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import static springfox.documentation.builders.RequestHandlerSelectors.basePacka
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,8 +21,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.paths.RelativePathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -59,7 +61,9 @@ public class SwaggerConfig {
               public String getApplicationBasePath() {
                 return basePath;
               }
-            });
+            })
+        .securitySchemes(securitySchemes())
+        .securityContexts(Collections.singletonList(securityContext()));
   }
 
   private ApiInfo apiInfo() {
@@ -68,6 +72,23 @@ public class SwaggerConfig {
         .description("Score API reference for developers.")
         .version(serverVersion)
         .build();
+  }
+
+  private static ArrayList<? extends SecurityScheme> securitySchemes() {
+    ArrayList<SecurityScheme> securitySchemes = new ArrayList<>();
+    securitySchemes.add(new ApiKey("Bearer", "Authorization", "header"));
+    return securitySchemes;
+  }
+
+  private SecurityContext securityContext() {
+    return SecurityContext.builder().securityReferences(defaultAuth()).build();
+  }
+
+  private List<SecurityReference> defaultAuth() {
+    AuthorizationScope authorizationScope = new AuthorizationScope("global", "");
+    AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+    authorizationScopes[0] = authorizationScope;
+    return Collections.singletonList(new SecurityReference("Bearer", authorizationScopes));
   }
 
   @Bean

--- a/score-server/src/main/java/bio/overture/score/server/controller/BenchmarkUploadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/BenchmarkUploadController.java
@@ -35,7 +35,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,13 +55,11 @@ public class BenchmarkUploadController extends UploadController {
   @Override
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/uploads")
   public @ResponseBody ObjectSpecification initializeMultipartUpload(
-      @RequestHeader(value = "access-token", required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "overwrite", required = false, defaultValue = "false")
           boolean overwrite,
       @RequestParam(value = "fileSize", required = true) long fileSize,
       @RequestParam(value = "md5", required = false) String md5,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
     return uploadService.initiateUpload(objectId, fileSize, md5, overwrite);
   }
@@ -71,11 +68,9 @@ public class BenchmarkUploadController extends UploadController {
   @RequestMapping(method = RequestMethod.DELETE, value = "/{object-id}/parts")
   @ResponseStatus(value = HttpStatus.OK)
   public void deletePart(
-      @RequestHeader(value = "access-token", required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "partNumber", required = true) int partNumber,
       @RequestParam(value = "uploadId", required = true) String uploadId,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
     // NO-OP
   }
@@ -84,7 +79,6 @@ public class BenchmarkUploadController extends UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/parts")
   @ResponseStatus(value = HttpStatus.OK)
   public void finalizePartUpload(
-      @RequestHeader(value = "access-token", required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "partNumber", required = true) int partNumber,
       @RequestParam(value = "uploadId", required = true) String uploadId,
@@ -97,7 +91,6 @@ public class BenchmarkUploadController extends UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}")
   @ResponseStatus(value = HttpStatus.OK)
   public void finalizeUpload(
-      @RequestHeader(value = "access-token", required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "uploadId", required = true) String uploadId) {
     // NO-OP
@@ -107,7 +100,6 @@ public class BenchmarkUploadController extends UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/recovery")
   @ResponseStatus(value = HttpStatus.OK)
   public void tryRecover(
-      @RequestHeader(value = "access-token", required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "fileSize", required = true) long fileSize) {
     // NO-OP

--- a/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
@@ -33,7 +33,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,31 +49,26 @@ public class DownloadController {
   @Autowired DownloadService downloadService;
 
   @RequestMapping(method = RequestMethod.GET, value = "/ping")
-  public @ResponseBody String ping(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) final String accessToken,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
-      HttpServletRequest request) {
+  public @ResponseBody String ping(HttpServletRequest request) {
 
     val ipAddress = HttpServletRequests.getIpAddress(request);
 
     log.info(
         "Requesting download of sentinel object id with access token {} (MD5) from {} and client version {}",
-        identifier(accessToken),
+        hashToken(request.getHeader(HttpHeaders.AUTHORIZATION)),
         ipAddress,
-        userAgent);
+        request.getHeader(HttpHeaders.USER_AGENT));
     return downloadService.getSentinelObject();
   }
 
   @PreAuthorize("@accessSecurity.authorize(authentication,#objectId)")
   @RequestMapping(method = RequestMethod.GET, value = "/{object-id}")
   public @ResponseBody ObjectSpecification downloadPartialObject(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "offset", required = true) long offset,
       @RequestParam(value = "length", required = true) long length,
       @RequestParam(value = "external", defaultValue = "false") boolean external,
       @RequestParam(value = "exclude-urls", defaultValue = "false") boolean excludeUrls,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
 
     val ipAddress = HttpServletRequests.getIpAddress(request);
@@ -82,13 +76,13 @@ public class DownloadController {
     log.info(
         "Requesting download of object id {} with access token {} (MD5) from {} and client version {}",
         objectId,
-        identifier(accessToken),
+        hashToken(request.getHeader(HttpHeaders.AUTHORIZATION)),
         ipAddress,
-        userAgent);
+        request.getHeader(HttpHeaders.USER_AGENT));
     return downloadService.download(objectId, offset, length, external, excludeUrls);
   }
 
-  protected String identifier(String accessToken) {
+  protected String hashToken(String accessToken) {
     String identifier = "<none>";
     if ((accessToken != null) && (!accessToken.isEmpty())) {
       identifier = TokenHasher.hashToken(accessToken);

--- a/score-server/src/main/java/bio/overture/score/server/controller/UploadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/UploadController.java
@@ -38,7 +38,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -58,25 +57,23 @@ public class UploadController {
   @ProjectCodeScoped
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/uploads")
   public @ResponseBody ObjectSpecification initializeMultipartUpload(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "overwrite", required = false, defaultValue = "false")
           boolean overwrite,
       @RequestParam(value = "fileSize", required = true) long fileSize,
       @RequestParam(value = "md5", required = false) String md5,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
 
-    log.info("Request received from client {}", userAgent);
+    log.info("Request received from client {}", request.getHeader(HttpHeaders.USER_AGENT));
     val ipAddress = HttpServletRequests.getIpAddress(request);
 
     log.info(
         "Initiating upload of object id {} with access token {} (MD5) having size of {} from {} using client version {}",
         objectId,
-        TokenHasher.hashToken(accessToken),
+        hashToken(request.getHeader(HttpHeaders.AUTHORIZATION)),
         Long.toString(fileSize),
         ipAddress,
-        userAgent);
+        request.getHeader(HttpHeaders.USER_AGENT));
     return uploadService.initiateUpload(objectId, fileSize, md5, overwrite);
   }
 
@@ -84,11 +81,9 @@ public class UploadController {
   @RequestMapping(method = RequestMethod.DELETE, value = "/{object-id}/parts")
   @ResponseStatus(value = HttpStatus.OK)
   public void deletePart(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "partNumber", required = true) int partNumber,
       @RequestParam(value = "uploadId", required = true) String uploadId,
-      @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
 
     val ipAddress = HttpServletRequests.getIpAddress(request);
@@ -98,9 +93,9 @@ public class UploadController {
         objectId,
         partNumber,
         uploadId,
-        TokenHasher.hashToken(accessToken),
+        hashToken(request.getHeader(HttpHeaders.AUTHORIZATION)),
         ipAddress,
-        userAgent);
+        request.getHeader(HttpHeaders.USER_AGENT));
     uploadService.deletePart(objectId, uploadId, partNumber);
   }
 
@@ -108,7 +103,6 @@ public class UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/parts")
   @ResponseStatus(value = HttpStatus.OK)
   public void finalizePartUpload(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "partNumber", required = true) int partNumber,
       @RequestParam(value = "uploadId", required = true) String uploadId,
@@ -121,7 +115,6 @@ public class UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}")
   @ResponseStatus(value = HttpStatus.OK)
   public void finalizeUpload(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "uploadId", required = true) String uploadId) {
     val watch = Stopwatch.createStarted();
@@ -133,7 +126,6 @@ public class UploadController {
   @RequestMapping(method = RequestMethod.POST, value = "/{object-id}/recovery")
   @ResponseStatus(value = HttpStatus.OK)
   public void tryRecover(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "fileSize", required = true) long fileSize) {
     uploadService.recover(objectId, fileSize);
@@ -142,7 +134,6 @@ public class UploadController {
   @ProjectCodeScoped
   @RequestMapping(method = RequestMethod.GET, value = "/{object-id}/status")
   public @ResponseBody UploadProgress getUploadProgress(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "object-id") String objectId,
       @RequestParam(value = "fileSize", required = true) long fileSize) {
     // TODO: if object id/upload id does not exist, throw not found exception
@@ -151,18 +142,14 @@ public class UploadController {
 
   @ProjectCodeScoped
   @RequestMapping(method = RequestMethod.GET, value = "/{object-id}")
-  public @ResponseBody Boolean isObjectExist(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
-      @PathVariable("object-id") String objectId) {
+  public @ResponseBody Boolean isObjectExist(@PathVariable("object-id") String objectId) {
     return uploadService.exists(objectId);
   }
 
   @ProjectCodeScoped
   @RequestMapping(method = RequestMethod.DELETE, value = "/{object-id}")
   @ResponseStatus(value = HttpStatus.OK)
-  public void cancelUpload(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
-      @PathVariable("object-id") String objectId) {
+  public void cancelUpload(@PathVariable("object-id") String objectId) {
     uploadService.cancelUpload(objectId, uploadService.getUploadId(objectId));
   }
 
@@ -173,16 +160,6 @@ public class UploadController {
     uploadService.cancelUploads();
   }
 
-  @ProjectCodeScoped
-  @RequestMapping(method = RequestMethod.GET, value = "/test/{object-id}")
-  @ResponseStatus(value = HttpStatus.OK)
-  public @ResponseBody String test(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION) final String accessToken,
-      @PathVariable(value = "object-id") String objectId) {
-    log.info("Test invoked!");
-    return "Upload Test Operation executed";
-  }
-
   /**
    * Exception handler specific to the Spring Security processing in this controller
    *
@@ -191,7 +168,6 @@ public class UploadController {
   @ExceptionHandler({AccessDeniedException.class})
   public ResponseEntity<Object> handleAccessDeniedException(
       HttpServletRequest req, AccessDeniedException ex) {
-    log.error("Token missing required scope to update project");
     return new ResponseEntity<Object>(
         "Token missing required scope to update project", new HttpHeaders(), HttpStatus.FORBIDDEN);
   }
@@ -200,4 +176,13 @@ public class UploadController {
   @Retention(RetentionPolicy.RUNTIME)
   @PreAuthorize("@projectSecurity.authorize(authentication,#objectId)")
   public @interface ProjectCodeScoped {}
+
+  /** Logging helper */
+  protected String hashToken(String accessToken) {
+    String identifier = "<none>";
+    if ((accessToken != null) && (!accessToken.isEmpty())) {
+      identifier = TokenHasher.hashToken(accessToken);
+    }
+    return identifier;
+  }
 }


### PR DESCRIPTION
* Apply code formatter

* Add /profile and custom swagger path to permitted requests

* Remove unused profile isTest variable

* Remove useless /test endpoint and log for failed access

* Standardize Auth handling for Download and Upload controllers
- Download and upload controller endpoints are now required to be authenticated by Spring HttpSecurity.
- Remove header parameters from controller endpoints, these are not required in the controller or services for anything other than logging, and the auth headers are handled by Spring HttpSecurity and not enforced by the controllers. this also causes requests without an Authorization token to be returned as 401 Unauthorized instead of 400 Bad Request.
- Add bearer token security scheme to swagger so that a tester can set their bearer token just once in the UI instead of separately for every endpoint.