### PR TITLE
replace admin-group with data_admin

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/config/PCGLAuthZConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/PCGLAuthZConfig.java
@@ -14,8 +14,6 @@ public class PCGLAuthZConfig {
 
   @NotNull private String host;
 
-  @NotNull private String adminGroup;
-
   @NotNull private String serviceId;
 
   @NotNull private String serviceUUID;

--- a/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZAuthorizationService.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZAuthorizationService.java
@@ -17,7 +17,7 @@ public class AuthZAuthorizationService {
    * @return
    */
   public boolean isAdmin(AuthZUserClaims claims) {
-    return claims.getGroups().contains(pcglAuthZConfig.getAdminGroup());
+    return claims.isDataAdmin();
   }
 
   /**

--- a/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZAuthorizationService.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZAuthorizationService.java
@@ -1,14 +1,9 @@
 package bio.overture.score.server.security.authz;
 
-import bio.overture.score.server.config.PCGLAuthZConfig;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AuthZAuthorizationService {
-
-  @Autowired private PCGLAuthZConfig pcglAuthZConfig;
 
   /**
    * Determine from AuthZUserClaims if a user is an admin.

--- a/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZUserClaims.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/authz/AuthZUserClaims.java
@@ -9,6 +9,7 @@ import lombok.Data;
 public class AuthZUserClaims {
 
   private final String sub;
+  private final boolean dataAdmin;
   private final List<String> editableStudies;
   private final List<String> readableStudies;
   private final List<String> groups;

--- a/score-server/src/main/java/bio/overture/score/server/security/authz/dto/AuthZUserDetailsResponse.java
+++ b/score-server/src/main/java/bio/overture/score/server/security/authz/dto/AuthZUserDetailsResponse.java
@@ -27,9 +27,9 @@ public class AuthZUserDetailsResponse {
       private String type;
     }
 
+    private boolean data_admin;
     private List<UserEmail> emails = new ArrayList<>();
     private String pcgl_id;
-    private boolean site_curator;
     private boolean site_admin;
   }
 
@@ -64,6 +64,7 @@ public class AuthZUserDetailsResponse {
 
     return AuthZUserClaims.builder()
         .sub(this.getUserinfo().getPcgl_id())
+        .dataAdmin(this.getUserinfo().isData_admin())
         .editableStudies(this.getStudy_authorizations().getEditable_studies())
         .readableStudies(this.getStudy_authorizations().getReadable_studies())
         .groups(groupNames)

--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -258,7 +258,6 @@ auth:
     provider: pcglauthz
 #    authz:
 #      host: https://authz.example.com
-#      admin-group: "PCGL:admin-group-name"
 #      service-id: SERVICE-LABEL
 #      service-uuid: 00000000-0000-0000-0000-0000000000000
 ---

--- a/score-server/src/test/resources/application.yml
+++ b/score-server/src/test/resources/application.yml
@@ -102,7 +102,6 @@ auth:
       realm: "myrealm"
     authz:
       host: https://authz.example.com
-      admin-group: "PCGL:admin-group-name"
       service-id: SERVICE-LABEL
       service-uuid: 00000000-0000-0000-0000-0000000000000
     scope:


### PR DESCRIPTION
## Summary

Due to recent changes in Authz, which now include a property "data_admin" to identify if user is an admin, this PR uses that property to identify an admin, instead of looking for the user's group.

## Description of Changes
- Removed environment variable  in `auth.server.authz.admin-group` from application.yaml, and other files
- Changed DTO `AuthzUserDetailsReponse` to add  boolean property `data_admin`
- Changed `isAdmin` function in AuthZAuthorizarionService.java to recognizes the property `userinfo.data_admin` as an admin

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
